### PR TITLE
Make all errors in building external libraries fatal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 # Set a name and version number for the project
 project(
@@ -19,10 +19,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Configure and build our external dependencies
 configure_file(external.cmake.in external/CMakeLists.txt @ONLY)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/external)
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/external)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/external COMMAND_ERROR_IS_FATAL ANY)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --build .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/external COMMAND_ERROR_IS_FATAL ANY)
 
 # Find the parafields library
 set(CMAKE_PREFIX_PATH


### PR DESCRIPTION
This fixes #10.